### PR TITLE
Function name

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,12 +33,13 @@
     "src"
   ],
   "scripts": {
-    "dev": "turbo _chore && tsc -w",
-    "build": "turbo _chore && rm -rf dist && tsc",
+    "dev": "pnpm _chore && tsc -w",
+    "build": "pnpm _chore && rm -rf dist && tsc",
     "test:unit": "vitest run",
     "test:lint": "tsc --noEmit --emitDeclarationOnly false && prettier --check .",
     "test:lint:fix": "prettier --write .",
-    "prepublishOnly": "turbo test && pnpm build"
+    "prepublishOnly": "pnpm test && pnpm build",
+    "_chore": "pnpm i"
   },
   "devDependencies": {
     "@aztec/accounts": "0.85.0-alpha-testnet.2",
@@ -56,7 +57,7 @@
     "@aztec/entrypoints": "0.85.0-alpha-testnet.2",
     "@aztec/protocol-contracts": "0.85.0-alpha-testnet.2",
     "@aztec/stdlib": "0.85.0-alpha-testnet.2",
-    "@obsidion/bridge": "0.5.0",
+    "@obsidion/bridge": "0.6.0",
     "@walletconnect/modal-sign-html": "^2.6.2",
     "@walletconnect/utils": "^2.11.2",
     "lodash-es": "^4.17.21",

--- a/src/serde.ts
+++ b/src/serde.ts
@@ -22,6 +22,7 @@ import { request } from "./utils.js";
 export function encodeFunctionCall(call: FunctionCall) {
   return {
     to: call.to.toString(),
+    name: call.name,
     selector: call.selector.toString(),
     args: call.args.map((x) => x.toString()),
   };
@@ -37,6 +38,12 @@ export async function decodeFunctionCall(pxe: PXE, fc: SerializedFunctionCall) {
   const args = fc.args.map((x) => Fr.fromHexString(x));
 
   const artifact = await getContractFunctionAbiFromPxe(pxe, to, selector);
+
+  if (fc.name !== artifact.name) {
+    throw new Error(
+      `Function call name mismatch: ${fc.name} !== ${artifact.name}`,
+    );
+  }
 
   const call: FunctionCall = {
     to,

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,8 @@ export type RpcEventsMap = {
 export type SerializedFunctionCall = {
   /** `AztecAddress` of the contract */
   to: string;
+  /** Name of the function to call */
+  name: string;
   // TODO: replace selector and args with encoded `data` similar to Ethereum?
   /** `FunctionSelector` of the contract method */
   selector: string;


### PR DESCRIPTION
Change:
- added `name` to `SerializedFunctionCall`
- verify that `name` matches `selector` [here](https://github.com/nemi-fi/wallet-sdk/blob/742780d05accabf84a45a628b9c364a024da1198/src/serde.ts#L42)

Rational: 
To provide better UX for users by displaying function name on sendTx popup UI without waiting for the completion of contract registration in wallet PXE. 

![Screenshot 2025-04-26 at 16 50 33](https://github.com/user-attachments/assets/87ba5737-c93e-4ca3-9503-c3afbd28a6a7)


