### PR TITLE
first

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -19,7 +19,7 @@ import type { FallbackOpenPopup } from "./Communicator.js";
 import type { Account } from "./exports/index.js";
 import { InjectedConnector, requestEip6963Providers } from "./injected.js";
 import type { Eip1193Provider, RpcRequestMap } from "./types.js";
-import { resolveAztecNode } from "./utils.js";
+import { getAztecChainId, resolveAztecNode } from "./utils.js";
 
 export class AztecWalletSdk {
   readonly #aztecNode: () => Promise<AztecNode>;
@@ -133,14 +133,19 @@ export class AztecWalletSdk {
   async watchAssets(
     assets: Parameters<RpcRequestMap["wallet_watchAssets"]>[0]["assets"],
   ) {
+    const chainId = await getAztecChainId(await this.#aztecNode());
     await this.#provider.request({
       method: "wallet_watchAssets",
-      params: [{ assets }],
+      params: [{ assets, chainId }],
     });
   }
 
   get connectors(): readonly Eip6963ProviderInfo[] {
     return get(this.#connectors).map((x) => ({ ...x.info })); // clone
+  }
+
+  get aztecNode() {
+    return this.#aztecNode;
   }
 
   get #connector() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export type RpcRequestMap = {
    * Requests the user to connect 1 or more accounts to the app. Should trigger a confirmation popup/modal.
    * @returns `AztecAddress[]` of the connected accounts. The first one must be the currently selected account.
    */
-  aztec_requestAccounts: () => string[];
+  aztec_requestAccounts: (chainId?: string) => string[];
 
   /**
    * Must **NOT** trigger a confirmation popup/modal.
@@ -18,6 +18,7 @@ export type RpcRequestMap = {
    * @returns the transaction hash
    */
   aztec_sendTransaction: (request: {
+    chainId: string;
     /** `AztecAddress` of the account that will send the transaction */
     from: string;
     /** `FunctionCall[]` to be executed in the transaction */
@@ -37,6 +38,7 @@ export type RpcRequestMap = {
    * @returns an array of return values (each being `Fr[]`) of the calls
    */
   aztec_call: (request: {
+    chainId: string;
     /** `AztecAddress` of the account that will the call will be simulated from */
     from: string;
     /** `FunctionCall[]` to be simulated */
@@ -51,6 +53,7 @@ export type RpcRequestMap = {
    * Requests the user to add an asset to the wallet. Must trigger a confirmation popup.
    */
   wallet_watchAssets: (request: {
+    chainId: string;
     assets: {
       // TODO: is this type namespaced enough? Could this clash with other chains which names start with "A"? E.g., Aleo also has an "ARC20" standard
       type: "ARC20";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -109,3 +109,14 @@ export function mergeTransactionRequests(
     registerSenders: requests.flatMap((r) => r.registerSenders ?? []),
   };
 }
+
+export async function getAztecChainId(aztecNode: AztecNode) {
+  const l1ChainId = await aztecNode.getChainId();
+  if (l1ChainId === 1115511) {
+    return "418719321"; // keccak256('aztec-testnet')[0:4]
+  } else if (l1ChainId === 31337) {
+    return "147120760"; // keccak256('aztec-sandbox')[0:4]
+  } else {
+    throw new Error(`Unsupported L1 chain ID: ${l1ChainId}`);
+  }
+}

--- a/src/wallets.ts
+++ b/src/wallets.ts
@@ -6,7 +6,10 @@ import {
 } from "./obsidion.js";
 
 type PartialObsidionPopupConnectorOptions = Partial<
-  Pick<ObsidionBridgeConnectorOptions, "walletUrl" | "artifactStrategy">
+  Pick<
+    ObsidionBridgeConnectorOptions,
+    "walletUrl" | "artifactStrategy" | "aztecNode"
+  >
 >;
 
 export function obsidion(params: PartialObsidionPopupConnectorOptions = {}) {
@@ -21,5 +24,6 @@ export function obsidion(params: PartialObsidionPopupConnectorOptions = {}) {
       uuid: "obsidion",
       name: "Obsidion",
       icon: "https://pbs.twimg.com/profile_images/1849068253685116928/MzTzv03r_400x400.jpg",
+      aztecNode: sdk.aztecNode(),
     });
 }


### PR DESCRIPTION

@olehmisar 

It's not complete and super simplistic but I need your feedback to know how much this is aligned with what you might have in your mind before going further.

All rpc call now has string `chainId` field ( see [types.ts](https://github.com/nemi-fi/wallet-sdk/blob/pr/handle-chainid/src/types.ts) ) which is determined by L1 chain id. Below is utility method used for that. 

```typescript
export async function getAztecChainId(aztecNode: AztecNode) {
  const l1ChainId = await aztecNode.getChainId();
  if (l1ChainId === 1115511) {
    return "418719321"; // keccak256('aztec-testnet')[0:4]
  } else if (l1ChainId === 31337) {
    return "147120760"; // keccak256('aztec-sandbox')[0:4]
  } else {
    throw new Error(`Unsupported L1 chain ID: ${l1ChainId}`);
  }
}
```

The above is called by 1) connectors for `connect()`, 2) eip1193Account for `sendTransaction()` and `simulateTransaction()` and 3) base aztecWalletSdk class for `watchAssets()`.

As for types.ts, i left chainId param for `aztec_requestAccounts` to avoid modifying `reown.ts` and `injected.ts` for now. If you see no problem, I can modify them in a way that takes node and get chain id from `getAztecChainId()` like obsidion.ts's connect() does.  


